### PR TITLE
Move list include out of macro if-else.

### DIFF
--- a/jomock/jomock.h
+++ b/jomock/jomock.h
@@ -16,12 +16,12 @@
 #include <Windows.h>
 #include <memoryapi.h>
 #else 
-#include <list>
 #include <cerrno>
 #include <unistd.h>
 #include <sys/mman.h>
 #include <memory>
 #endif
+#include <list>
 
 
 using namespace std;


### PR DESCRIPTION
System:
- OS: Windows 11 x64
- Compiler: MinGW-GCC 14.1.0
- C++ Standard: c++23
---
Forked `main` branch and attempted to build Header file into project unit tests.  Ran into issue where usage of `std::list` was undefined.  I am not sure if the Window headers included in the macro if-statement contain the `#include <list>` for GCC compilers.  I assume they do for Visual Studio's compiler.  Due to C++ headers typically having header guards in them, I do not foresee an issue with moving the `#include <list>` outside of the macro if-statement.  This allows my project to compile with the jomock header.